### PR TITLE
add src link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,11 @@ html, body {
     font-size:12px;
 }
 
+.timer__src {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px dotted black;
+}
 .ticker {
     display:block;
     width:225px;

--- a/src/Ticker.js
+++ b/src/Ticker.js
@@ -19,7 +19,9 @@ export function Ticker({timer, target}) {
     const value = prettify( rawValue > 10 ? Math.ceil(rawValue) : rawValue.toPrecision(2) );
     return ( 
         <div className={`ticker ${timer.isNsfw ? "ticker--nsfw" : ""}`}>
-            <div className="ticker__name">{timer.name}</div>
+            <div className="ticker__name">
+               {timer.src ? <a className="timer__src" href={timer.src}>{timer.name}</a> : timer.name} 
+            </div>
             <div className="ticker__value">{value}</div>
             <div className="ticker__unit">{timer.unit}</div>
         </div>


### PR DESCRIPTION
Add source links to timers that have them. 
![image](https://user-images.githubusercontent.com/6331864/96333468-fd271080-1061-11eb-9af8-b45c8031bd4e.png)


Later I'd like to expand this to be a full text explanation but for now linking to a source should be more than enough credibility for a bad calculation on the internet. 